### PR TITLE
Update readme and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - unreleased
+## [0.1.0] - 2015-05-22
+
+### Changed
+
+- Improved README and Changelog formatting.
+
+## [0.0.4] - 2015-05-22
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ $InputTCPServerRun 10514
 
 ## Installation
 
-### Installing npm (node package manager)
-
 ``` bash
 npm install winston-rsyslog2
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "winston-rsyslog2",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Rsyslog transport for winston",
     "keywords": [
         "logging",


### PR DESCRIPTION
Thanks for the release. 

A heading was missed being removed and the version wasn't added to the Changelog. I've dealt with those details now, and bumped the version again, so the result is ready to be released as winston-rsyslog2 0.1.0.
